### PR TITLE
Expose internal library.

### DIFF
--- a/lib/flutter_ble_lib.dart
+++ b/lib/flutter_ble_lib.dart
@@ -37,11 +37,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:flutter_ble_lib/src/_internal.dart';
-import 'package:flutter_ble_lib/src/_managers_for_classes.dart';
+import 'package:flutter_ble_lib/src/internal.dart';
 import 'package:flutter_ble_lib/src/util/_transaction_id_generator.dart';
 
-import 'src/_managers_for_classes.dart';
 
 part 'error/ble_error.dart';
 

--- a/lib/src/base_entities.dart
+++ b/lib/src/base_entities.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 class InternalService {
   final int _id;

--- a/lib/src/bridge/bluetooth_state_mixin.dart
+++ b/lib/src/bridge/bluetooth_state_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin BluetoothStateMixin on FlutterBLE {
   final Stream<dynamic> _adapterStateChanges =

--- a/lib/src/bridge/characteristics_mixin.dart
+++ b/lib/src/bridge/characteristics_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin CharacteristicsMixin on FlutterBLE {
   final Stream<dynamic> _characteristicsMonitoringEvents =

--- a/lib/src/bridge/descriptors_mixin.dart
+++ b/lib/src/bridge/descriptors_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin DescriptorsMixin on FlutterBLE {
   Future<DescriptorWithValue> readDescriptorForPeripheral(

--- a/lib/src/bridge/device_connection_mixin.dart
+++ b/lib/src/bridge/device_connection_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin DeviceConnectionMixin on FlutterBLE {
   final Stream<dynamic> _peripheralConnectionStateChanges =

--- a/lib/src/bridge/device_rssi_mixin.dart
+++ b/lib/src/bridge/device_rssi_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin RssiMixin on FlutterBLE {
   Future<int> rssi(Peripheral peripheral, String transactionId) async {

--- a/lib/src/bridge/devices_mixin.dart
+++ b/lib/src/bridge/devices_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin DevicesMixin on FlutterBLE {
   Future<List<Peripheral>> knownDevices(

--- a/lib/src/bridge/discovery_mixin.dart
+++ b/lib/src/bridge/discovery_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin DiscoveryMixin on FlutterBLE {
   Future<void> discoverAllServicesAndCharacteristics(

--- a/lib/src/bridge/lib_core.dart
+++ b/lib/src/bridge/lib_core.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 abstract class FlutterBLE {
   final InternalBleManager _manager;

--- a/lib/src/bridge/log_level_mixin.dart
+++ b/lib/src/bridge/log_level_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin LogLevelMixin on FlutterBLE {
   Future<void> setLogLevel(LogLevel logLevel) async {

--- a/lib/src/bridge/mtu_mixin.dart
+++ b/lib/src/bridge/mtu_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin MtuMixin on FlutterBLE {
   Future<int> requestMtu(

--- a/lib/src/bridge/scanning_mixin.dart
+++ b/lib/src/bridge/scanning_mixin.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 mixin ScanningMixin on FlutterBLE {
   Stream<ScanResult>? _activeScanEvents;

--- a/lib/src/internal.dart
+++ b/lib/src/internal.dart
@@ -1,4 +1,4 @@
-library _internal;
+library internal;
 
 import 'dart:async';
 import 'dart:convert';
@@ -12,8 +12,6 @@ import 'package:flutter_ble_lib/src/_constants.dart';
 import 'package:flutter_ble_lib/src/_containers.dart';
 import 'package:flutter_ble_lib/src/util/_transaction_id_generator.dart';
 import 'package:flutter_ble_lib/src/util/_transformers.dart';
-
-import '_managers_for_classes.dart';
 
 part 'base_entities.dart';
 
@@ -40,3 +38,5 @@ part 'bridge/log_level_mixin.dart';
 part 'bridge/mtu_mixin.dart';
 
 part 'bridge/scanning_mixin.dart';
+
+part 'managers_for_classes.dart';

--- a/lib/src/internal_ble_manager.dart
+++ b/lib/src/internal_ble_manager.dart
@@ -1,4 +1,4 @@
-part of _internal;
+part of internal;
 
 class InternalBleManager
     implements

--- a/lib/src/managers_for_classes.dart
+++ b/lib/src/managers_for_classes.dart
@@ -1,8 +1,4 @@
-import 'dart:typed_data';
-
-import 'package:flutter_ble_lib/flutter_ble_lib.dart';
-
-import '_internal.dart';
+part of internal;
 
 abstract class ManagerForPeripheral {
   Future<void> connectToPeripheral(


### PR DESCRIPTION
This a quick alternative to move the different managers to the public library of the package.